### PR TITLE
Implement Stakeholders Interview

### DIFF
--- a/src/pages/practice/stakeholders-interview.md
+++ b/src/pages/practice/stakeholders-interview.md
@@ -62,5 +62,5 @@ howTo: >-
 
     * Empathy Mapping（共感マッピング）: <https://openpracticelibrary.com/practice/empathy-mapping/>
 
-    * How to prepare interview: (Sorry but the link is expired.)
+    * How to prepare interview: (Sorry but the link is incorrect.)
 ---

--- a/src/pages/practice/stakeholders-interview.md
+++ b/src/pages/practice/stakeholders-interview.md
@@ -1,7 +1,7 @@
 ---
 templateKey: practice-page
-title: Stakeholders Interview
-subtitle: Help identify concrete objectives, targets and main priority areas
+title: ステークホルダインタビュー
+subtitle: 具体的な目標や優先すべき領域を特定する
 date: 2021-02-09T09:45:51.714Z
 authors:
   - dsunwar
@@ -11,62 +11,56 @@ tags: []
 mobiusTag: discovery
 icon: /images/screenshot-2021-02-05-at-16.11.47.png
 whatIs: >-
-  * One on one conversation to help better understand what stakeholders want and
-  need from the product. * An opportunity to gather useful information from
-  three main areas, and more for e.g:\
-    User needs, Business goals and Technical limitations to gather valuable insights.
-  * Analyze various viewpoints of perceptions and aspirations of each stakeholder who have a product success interest
+  * ステークホルダが製品に何を求め、必要としているかをより理解するために１対１で会話を行います。
+  * 適切なインタビューからはユーザーのニーズ、ビジネスの目標、技術的な制限の3つの観点から有用な情報や洞察を得ることができます。
+  * プロダクトの成功に関心を持つステークホルダ達の認識や要望を分析していきます。
 
 
-  ** Who: are stakeholders? **
+  ** ステークホルダとは誰のことか？ **
 
-    * Within the organisation, stakeholders are anyone who can offer useful product advice and ultimately help simplify the design process.
-    * Stakeholders can be anyone from the organisation, depending on the projects high level employees, lower-level employees or even influential users. The job title varies across various organisations. For e.g: Product Owner, Head of IT, Head of Data, IT Manager, Marketing Manager etc.
+    * 組織内のステークホルダは、製品に関する有益なアドバイスを行い、デザインプロセスを簡素化するのに役立つ人物を指します。
+    * 組織内の誰もがステークホルダになり得ます。誰がステークホルダになるかはプロジェクトに寄って異なりますが、役員等のの上位職、一般従業員、影響力のある社内ユーザー等が該当します。例えば、プロダクトオーナー、IT部門長、データ部門長、ITマネージャー、マーケティングマネージャー等です。
 whyDo: >-
   
 
-  * Better understanding and learning about the product, its vision and context through different lenses.
+  * 製品とそのビジョン、コンテキストについての自分以外のステークホルダ達の視点から深く理解することができるようになります。
 
-  * Identifying priorities: helping to identify concrete objectives, targets and identify main priority areas
+  * 優先事項の特定：ビジネスの具体的な目標や優先領域の決定に役立ちます。
 
-  * Understanding business requirements, their team and culture
+  * ビジネス要件、チーム、文化を理解に役立ちます。
 
-  * Understanding their target market and customer awareness (users)
+  * ステークホルダが目標市場と顧客認知をどう考えているか理解することができる。
 
-  * Compile both qualitative and quantitative data
+  * 定性的および定量的なデータの収集。
 
-  * Avoid expensive, intense, conventional research time
+  * 時間とコストがかかる、従来型の市場・顧客ニーズの探索の代替となりえます。
 howTo: >-
-  * **Outcome:** Align goal with the PO on the purpose and intent of the
-  interview understand the Big WHY
+  * **得られる成果(Outcome):** インタビューの目的と意図についてPOと合意します。
 
-  * **Stakeholders Map:** Finding the relevant stakeholders is key. Go through stakeholders mapping workshops to understand their role and how they impact certain projects.
+  * **ステークホルダマップ:** 関連するステークホルダーを見つけることが重要です。各ステークホルダの役割と、プロジェクトにどのように影響を与えるかを理解するために、ステークホルダーマッピングのワークショップを実施します。
 
-  * **Prep questions:** work collaboratively, categorise with the areas that need further investigation. Helpful practice: Affinity map
+  * **質問の準備:** インタビューで明らかにしたい領域をカテゴリ分けします。アフィニティ・ダイアグラム（親和図）が有効です。（訳注：類似点を見出してグループ分けする手法。様々なステークホルダを付箋で書き出し、彼らを興味や影響力等の観点でグループ分けする。）
 
-  * **Logistics:** Discuss date, time and environment you will conduct interviews for e.g: face to face, virtual meeting, technologies suitable for both parties and many more.
+  * **インタビューの調整・手配:** インタビューの日時や環境について合意します。対面/リモート、場所/リモート会議ツール、等。
 
-    **Some Helpful Tips:**
+    **お役立ち情報:** 
 
-    * **Establish psychological safety:** It is essential for the participants to create a secure and comfortable atmosphere. And they feel relaxed and safe. For example, clarify the intention of the interview, when, how and to whom the information will be shared, promote active listening, encourage them to reflect and answer.
-    * **Pair up with the other team members:** This will validate a lot of technical, business, marketing buzzwords
-    * **Silence is good:** let them think and reflect back and answer, it’s not awkward.
-    * **Time of the interview:** No longer than 45mins to 1 hours
-    * **Methodologies/ Practices that are helpful to visualise the data collected:** empathy mapping, Affinity mapping, User Journey Mapping, Proto-personas
-    * **Questions:** Don’t lead the interviewee with direct questions. Ask open ended questions
-    * **What if:**
-      There is a project manager and who you have agreed on the project plan should you skip the stakeholders interview? Absolutely not.\
-      \
-      \
-      **Helpful links:**
+    * **心理的安全性の確率:** 参加者がリラックスして話しやすい雰囲気を作り出すことが不可欠です。インタビューの意図を明確にし、情報がいつ、どのように、誰に共有されるかを明示し、アクティブリスニングを促して回答できる状況を作りましょう。
+    * **他のチームメンバーとペアになる:** 技術、ビジネス、マーケティングの専門用語の検証に役立ちます。
+    * **質問者は多くを喋らない:** インタビューを受ける人に考え、反芻し、回答させるようにしましょう。沈黙を気まずく感じる必要はありません。
+    * **インタビュー時間を区切る:** 45分から1時間程度が良いとされます。
+    * **データを可視化する手法:** 共感マッピング（Empathy Mapping）、親和図（Affinity Mapping）、ユーザー（カスタマー）ジャーニーマッピング（User Journey Mapping）、プロトペルソナ（Proto-personas）
+    * **質問の仕方:** インタビューを受ける人を誘導するような質問はやめましょう。オープンクエスチョン（Yes/Noで答える形式の質問ではなく、◯◯はどうですか？などのフリーテキストで答える形式の質問）が望ましいです。
+    * **もしも:**
+      プロジェクトマネージャーとプロジェクト計画に合意済みの場合、ステークホルダのインタビューをスキップも良いででしょうか？いいえ、絶対にスキップすべきではありません。
 
-      Preparatory research: \
-      <https://www.thisisservicedesigndoing.com/methods/preparatory-research>
+  **Helpful links:**
 
-      Tips for writing a discussion guide: <https://medium.com/design-research-methods/tips-for-writing-a-discussion-guide-c08459131a54>
+    * Preparatory Research（インタビューを実施する前の準備）: <https://www.thisisservicedesigndoing.com/methods/preparatory-research>
 
-      Empathy mapping: <https://openpracticelibrary.com/practice/empathy-mapping/>
+    * Tips for Writing a Discussion Guide（ディスカッションガイドを書くための留意点）: <https://medium.com/design-research-methods/tips-for-writing-a-discussion-guide-c08459131a54>
 
-      How to prepare interview: \
-      <https://medium.com/design-research-methods/tips-for-writing-a-discussion-guide-c08459131a54>
+    * Empathy Mapping（共感マッピング）: <https://openpracticelibrary.com/practice/empathy-mapping/>
+
+    * How to prepare interview: (Sorry but the link is expired.)
 ---


### PR DESCRIPTION
Stakeholder Interviewの翻訳

注意）本家は末尾の「How to prepare interview」のリンクが誤っている（Tips for Writing a Discussion Guideと同一のリンクになっている）ため、リンクを消した。正しいリンクは不明。